### PR TITLE
Fix makefile to build the ovl file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,10 +185,8 @@ DEPENDS	:=	$(OFILES:.o=.d)
 #---------------------------------------------------------------------------------
 all	:	 $(OUTPUT).ovl
 
-$(OUTPUT).ovl		:	$(OUTPUT).nro
-	@cp $(OUTPUT).nro $(OUTPUT).ovl
-
-$(OUTPUT).nro	:   $(OUTPUT).elf $(OUTPUT).nacp 
+$(OUTPUT).ovl		:	$(OUTPUT).elf $(OUTPUT).nacp 
+	@elf2nro $< $@ $(NROFLAGS)
 	@echo "built ... $(notdir $(OUTPUT).ovl)"
 
 $(OUTPUT).elf	:	$(OFILES) libs/libtesla/lib/libtesla.a


### PR DESCRIPTION
The `@echo "built ... $(notdir $(OUTPUT).ovl)"` was overriding the build step in switch_rules. So the NRO file was never being built and it wasn't able to copy the nro file to be a ovl file in the next step. Instead this just runs elf2nro and have it output a opl file directly.